### PR TITLE
Update 1.21.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.7-SNAPSHOT'
+	id 'fabric-loom' version '1.9-SNAPSHOT'
 	id 'maven-publish'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,16 +3,16 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/versions.html
-	minecraft_version=1.21.1
-	yarn_mappings=1.21.1+build.3
-	loader_version=0.16.5
-	modmenu_version=11.0.2
+	minecraft_version=1.21.4
+	yarn_mappings=1.21.4+build.7
+	loader_version=0.16.9
+	modmenu_version=13.0.0-beta.1
 
 # Mod Properties
-	mod_version = 1.3.6-1.21.1
+	mod_version = 1.3.6-1.21.4
 
 	maven_group = fr.alice
 	archives_base_name = featurs-mod
 
 # Dependencies
-	fabric_version=0.103.0+1.21.1
+	fabric_version=0.113.0+1.21.4

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/fr/idarkay/morefeatures/mixin/InGameHudMixin.java
+++ b/src/main/java/fr/idarkay/morefeatures/mixin/InGameHudMixin.java
@@ -63,8 +63,8 @@ public abstract class InGameHudMixin {
 //    @Final
 //    private static Identifier PUMPKIN_BLUR;
 
-    private static final Identifier INVENTORY_TEXTURE = Identifier.ofVanilla("textures/gui/container/inventory.png");
-            //new Identifier("textures/gui/container/inventory.png");
+    private static final Identifier AMBIENT_TEXTURE = Identifier.ofVanilla("textures/gui/sprites/hud/effect_background_ambient.png");
+    private static final Identifier BACKGROUND_TEXTURE = Identifier.ofVanilla("textures/gui/sprites/hud/effect_background.png");
 
     @Shadow
     public abstract TextRenderer getTextRenderer();
@@ -116,9 +116,9 @@ public abstract class InGameHudMixin {
                     RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
                     float f = 1.0F;
                     if (statusEffectInstance.isAmbient()) {
-                        context.drawTexture((a) -> RenderLayer.getGui(), null, k, l, 0F, 0F, 165, 166, 24, 24);
+                        context.drawTexture(RenderLayer::getGuiTextured, AMBIENT_TEXTURE, k, l, 0F, 0F, 24, 24, 24, 24);
                     } else {
-                        context.drawTexture((a) -> RenderLayer.getGui(), INVENTORY_TEXTURE, k, l, 0F, 0F, 141, 166, 24, 24);
+                        context.drawTexture(RenderLayer::getGuiTextured, BACKGROUND_TEXTURE, k, l, 0F, 0F, 24, 24, 24, 24);
                         if (statusEffectInstance.getDuration() <= 200) {
                             int m = 10 - statusEffectInstance.getDuration() / 20;
                             f = MathHelper.clamp(
@@ -130,14 +130,15 @@ public abstract class InGameHudMixin {
 
                     Sprite sprite = statusEffectSpriteManager.getSprite(statusEffect);
 
-                    final float finalF = f;
+                    final float finalF = 1;
                     final int finalL = l;
                     final int finalK = k;
                     list.add(() -> {
                         RenderSystem.setShaderTexture(0, sprite.getAtlasId());
                         RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, finalF);
                         //1.20.4 // context.drawSprite(finalK + 3, finalL + 3, 0, 18, 18, sprite);
-                        context.drawSpriteStretched((a) -> RenderLayer.getGui(), sprite, finalK + 3, finalL + 3, 18, 18, 0);
+                        context.drawSpriteStretched(RenderLayer::getGuiTextured, sprite, finalK + 3, finalL + 3, 18, 18);
+                        //context.drawGuiTexture(RenderLayer::getGuiTextured, sprite.getAtlasId(), finalK + 3, finalL + 3, 18, 18);
 
                         Text time = StatusEffectUtil.getDurationText(statusEffectInstance, 1.0F, 20);
                         MultilineText.create(textRenderer, time).drawWithShadow(context, finalK, finalL + 25, 1, 8355711);

--- a/src/main/java/fr/idarkay/morefeatures/mixin/InGameHudMixin.java
+++ b/src/main/java/fr/idarkay/morefeatures/mixin/InGameHudMixin.java
@@ -10,6 +10,7 @@ import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.hud.InGameHud;
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
+import net.minecraft.client.render.RenderLayer;
 import net.minecraft.client.render.RenderTickCounter;
 import net.minecraft.client.texture.Sprite;
 import net.minecraft.client.texture.StatusEffectSpriteManager;
@@ -58,9 +59,9 @@ public abstract class InGameHudMixin {
 //
 //    @Shadow protected abstract void drawTextBackground(MatrixStack matrixStack, TextRenderer textRenderer, int i, int j, int k);
 
-    @Shadow
-    @Final
-    private static Identifier PUMPKIN_BLUR;
+//    @Shadow
+//    @Final
+//    private static Identifier PUMPKIN_BLUR;
 
     private static final Identifier INVENTORY_TEXTURE = Identifier.ofVanilla("textures/gui/container/inventory.png");
             //new Identifier("textures/gui/container/inventory.png");
@@ -115,9 +116,9 @@ public abstract class InGameHudMixin {
                     RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
                     float f = 1.0F;
                     if (statusEffectInstance.isAmbient()) {
-                        context.drawTexture(INVENTORY_TEXTURE, k, l, 165, 166, 24, 24);
+                        context.drawTexture((a) -> RenderLayer.getGui(), null, k, l, 0F, 0F, 165, 166, 24, 24);
                     } else {
-                        context.drawTexture(INVENTORY_TEXTURE, k, l, 141, 166, 24, 24);
+                        context.drawTexture((a) -> RenderLayer.getGui(), INVENTORY_TEXTURE, k, l, 0F, 0F, 141, 166, 24, 24);
                         if (statusEffectInstance.getDuration() <= 200) {
                             int m = 10 - statusEffectInstance.getDuration() / 20;
                             f = MathHelper.clamp(
@@ -135,7 +136,8 @@ public abstract class InGameHudMixin {
                     list.add(() -> {
                         RenderSystem.setShaderTexture(0, sprite.getAtlasId());
                         RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, finalF);
-                        context.drawSprite(finalK + 3, finalL + 3, 0, 18, 18, sprite);
+                        //1.20.4 // context.drawSprite(finalK + 3, finalL + 3, 0, 18, 18, sprite);
+                        context.drawSpriteStretched((a) -> RenderLayer.getGui(), sprite, finalK + 3, finalL + 3, 18, 18, 0);
 
                         Text time = StatusEffectUtil.getDurationText(statusEffectInstance, 1.0F, 20);
                         MultilineText.create(textRenderer, time).drawWithShadow(context, finalK, finalL + 25, 1, 8355711);


### PR DESCRIPTION
Update to 1.21.4

Bugfixes:

Inventory flickered when an effect ended
Effect-backgrounds weren't properly displayed